### PR TITLE
Fix/pn order

### DIFF
--- a/python/src/multigroup/Metadata.python.cpp
+++ b/python/src/multigroup/Metadata.python.cpp
@@ -34,8 +34,9 @@ void wrapMetadata( python::module& module, python::module& ) {
 
     python::init< std::string, std::string, std::string,
                   double, double, double,
-                  unsigned int, std::map< unsigned int, unsigned int >,
-                  unsigned int, unsigned int,
+                  unsigned int, unsigned int, unsigned int,
+                  std::map< unsigned int, unsigned int >,
+                  std::map< unsigned int, unsigned int >,
                   std::optional< std::string >,
                   std::optional< std::string >,
                   std::optional< double >,
@@ -43,8 +44,11 @@ void wrapMetadata( python::module& module, python::module& ) {
                   std::optional< int > >(),
     python::arg( "zaid" ), python::arg( "libname" ),
     python::arg( "process" ), python::arg( "awr" ),
-    python::arg( "temperature" ), python::arg( "dilution" ), python::arg( "groups" ),
-    python::arg( "outgoing" ), python::arg( "reactions" ), python::arg( "legendre" ),
+    python::arg( "temperature" ), python::arg( "dilution" ),
+    python::arg( "groups" ),
+    python::arg( "reactions" ), python::arg( "legendre" ),
+    python::arg( "outgoing_groups" ) = std::map< unsigned int, unsigned int >{},
+    python::arg( "outgoing_legendre" ) = std::map< unsigned int, unsigned int >{},
     python::arg( "information" ) = std::nullopt,
     python::arg( "source" ) = std::nullopt,
     python::arg( "weight" ) = std::nullopt,
@@ -52,23 +56,24 @@ void wrapMetadata( python::module& module, python::module& ) {
     python::arg( "downscatter" ) = std::nullopt,
     "Initialise the record\n\n"
     "Arguments:\n"
-    "    self           the metadata\n"
-    "    zaid           the zaid of the table\n"
-    "    libname        the library name\n"
-    "    process        the processing date\n"
-    "    awr            the atomic weight ratio of the target (with respect\n"
-    "                   to the neutron mass)\n"
-    "    temperature    the temperature of the target\n"
-    "    dilution       the dilution (aka sigma0)\n"
-    "    groups         the number of groups in the primary group structure\n"
-    "    outgoing       the number of groups in the outgoing group structures\n"
-    "    reactions      the number of reactions defined in the table\n"
-    "    legendre       the number of Legendre moments in the table\n"
-    "    information    the table information line (optional)\n"
-    "    source         the source date (optional)\n"
-    "    weight         the atomic weight of the target (optional)\n"
-    "    upscatter      the number of upscatter groups (optional)\n"
-    "    downscatter    the number of downscatter groups (optional)"
+    "    self                the metadata\n"
+    "    zaid                the zaid of the table\n"
+    "    libname             the library name\n"
+    "    process             the processing date\n"
+    "    awr                 the atomic weight ratio of the target (with respect\n"
+    "                        to the neutron mass)\n"
+    "    temperature         the temperature of the target\n"
+    "    dilution            the dilution (aka sigma0)\n"
+    "    groups              the number of groups in the primary group structure\n"
+    "    reactions           the number of reactions defined in the table\n"
+    "    legendre            the number of Legendre moments in the table\n"
+    "    outgoing_group      the number of groups in the outgoing group structures (optional)\n"
+    "    outgoing_legendre   the number of groups in the outgoing group structures (optional)\n"
+    "    information         the table information line (optional)\n"
+    "    source              the source date (optional)\n"
+    "    weight              the atomic weight of the target (optional)\n"
+    "    upscatter           the number of upscatter groups (optional)\n"
+    "    downscatter         the number of downscatter groups (optional)"
   )
   .def_property_readonly(
 
@@ -160,6 +165,16 @@ void wrapMetadata( python::module& module, python::module& ) {
     &Record::numberOutgoingGroups,
     python::arg( "particle" ),
     "The number of outgoing groups defined by this record for the particle\n\n"
+    "Arguments:\n"
+    "    self       the metadata\n"
+    "    particle   the outgoing particle identifier"
+  )
+  .def(
+
+    "number_outgoing_legendre_moments",
+    &Record::numberOutgoingLegendreMoments,
+    python::arg( "particle" ),
+    "The number of outgoing Legendre moments defined by this record"
     "Arguments:\n"
     "    self       the metadata\n"
     "    particle   the outgoing particle identifier"

--- a/python/test/Test_NDItk_MultigroupTable.py
+++ b/python/test/Test_NDItk_MultigroupTable.py
@@ -42,6 +42,9 @@ class Test_NDItk_MultigroupTable( unittest.TestCase ) :
             self.assertEqual( 3, metadata.number_outgoing_groups( 0 ) )
             self.assertEqual( 2, metadata.number_outgoing_groups( 1001 ) )
             self.assertEqual( 2, metadata.number_reactions )
+            self.assertEqual( 2, metadata.number_legendre_moments )
+            self.assertEqual( 2, metadata.number_outgoing_legendre_moments( 0 ) )
+            self.assertEqual( 2, metadata.number_outgoing_legendre_moments( 1001 ) )
 
             # verify content - primary energy boundaries
             structure = chunk.primary_group_boundaries
@@ -406,29 +409,47 @@ class Test_NDItk_MultigroupTable( unittest.TestCase ) :
 
             # verify content - outgoing heating numbers: 0
             heating = chunk.outgoing_heating_numbers( 0 )
-            self.assertEqual( 3, heating.number_groups )
+            self.assertEqual( 7, heating.number_groups )
             self.assertAlmostEqual( 21  , heating.values[0] )
             self.assertAlmostEqual( 11  , heating.values[1] )
             self.assertAlmostEqual(  5.1, heating.values[2] )
+            self.assertAlmostEqual(  3  , heating.values[3] )
+            self.assertAlmostEqual(  4  , heating.values[4] )
+            self.assertAlmostEqual(  6  , heating.values[5] )
+            self.assertAlmostEqual(  7  , heating.values[6] )
 
             # verify content - outgoing heating numbers: 1001
             heating = chunk.outgoing_heating_numbers( 1001 )
-            self.assertEqual( 2, heating.number_groups )
-            self.assertAlmostEqual( 25, heating.values[0] )
-            self.assertAlmostEqual( 15, heating.values[1] )
+            self.assertEqual( 7, heating.number_groups )
+            self.assertAlmostEqual( 25  , heating.values[0] )
+            self.assertAlmostEqual( 15  , heating.values[1] )
+            self.assertAlmostEqual(  9.1, heating.values[2] )
+            self.assertAlmostEqual(  7  , heating.values[3] )
+            self.assertAlmostEqual(  8  , heating.values[4] )
+            self.assertAlmostEqual( 10  , heating.values[5] )
+            self.assertAlmostEqual( 11  , heating.values[6] )
 
             # verify content - outgoing kerma: 0
             kerma = chunk.outgoing_kerma( 0 )
-            self.assertEqual( 3, kerma.number_groups )
+            self.assertEqual( 7, kerma.number_groups )
             self.assertAlmostEqual( 210, kerma.values[0] )
             self.assertAlmostEqual( 110, kerma.values[1] )
             self.assertAlmostEqual(  51, kerma.values[2] )
+            self.assertAlmostEqual(  30, kerma.values[3] )
+            self.assertAlmostEqual(  40, kerma.values[4] )
+            self.assertAlmostEqual(  60, kerma.values[5] )
+            self.assertAlmostEqual(  70, kerma.values[6] )
 
             # verify content - outgoing kerma: 1001
             kerma = chunk.outgoing_kerma( 1001 )
-            self.assertEqual( 2, kerma.number_groups )
+            self.assertEqual( 7, kerma.number_groups )
             self.assertAlmostEqual( 250, kerma.values[0] )
             self.assertAlmostEqual( 150, kerma.values[1] )
+            self.assertAlmostEqual(  91, kerma.values[2] )
+            self.assertAlmostEqual(  70, kerma.values[3] )
+            self.assertAlmostEqual(  80, kerma.values[4] )
+            self.assertAlmostEqual( 100, kerma.values[5] )
+            self.assertAlmostEqual( 110, kerma.values[6] )
 
         # the data is given explicitly
         chunk = MultigroupTable( zaid = '92235.711nm', libname = 'mendf71x',
@@ -497,10 +518,10 @@ class Test_NDItk_MultigroupTable( unittest.TestCase ) :
                                                                 0, 1 ], 7, 2 ) ] )                                 ],
                                  outgoing = [ EnergyGroupStructure( 0, [ 20., 10., 5, 1e-11 ] ),
                                               EnergyGroupStructure( 1001, [ 20., 10., 1e-11 ] ) ],
-                                 outgoing_heating = [ HeatingNumbers( 0, [ 21., 11., 5.1 ] ),
-                                                      HeatingNumbers( 1001, [ 25., 15. ] ) ],
-                                 outgoing_kerma = [ Kerma( 0, [ 210., 110., 51. ] ),
-                                                    Kerma( 1001, [ 250., 150. ] ) ] )
+                                 outgoing_heating = [ HeatingNumbers( 0, [ 21., 11., 5.1, 3., 4., 6., 7. ] ),
+                                                      HeatingNumbers( 1001, [ 25., 15., 9.1, 7., 8., 10., 11. ] ) ],
+                                 outgoing_kerma = [ Kerma( 0, [ 210., 110., 51., 30., 40., 60., 70. ] ),
+                                                    Kerma( 1001, [ 250., 150., 91., 70., 80., 100., 110. ] ) ] )
 
         verify_chunk( self, chunk )
 

--- a/python/test/multigroup/Test_NDItk_multigroup_Metadata.py
+++ b/python/test/multigroup/Test_NDItk_multigroup_Metadata.py
@@ -36,7 +36,11 @@ class Test_NDItk_multigroup_Metadata( unittest.TestCase ) :
                      'num_grps_0\n'
                      '    30\n'
                      'num_grps_1001\n'
-                     '    250\n' )
+                     '    250\n'
+                     'pn_order_0\n'
+                     '    2\n'
+                     'pn_order_1001\n'
+                     '    2\n' )
 
     def test_component( self ) :
 
@@ -58,6 +62,8 @@ class Test_NDItk_multigroup_Metadata( unittest.TestCase ) :
             self.assertEqual(   5, chunk.number_legendre_moments )
             self.assertEqual( None, chunk.number_upscatter_groups )
             self.assertEqual( None, chunk.number_downscatter_groups )
+            self.assertEqual(   2, chunk.number_outgoing_legendre_moments( 0 ) )
+            self.assertEqual(   2, chunk.number_outgoing_legendre_moments( 1001 ) )
 
             self.assertEqual( self.chunk_string, chunk.to_string() )
 
@@ -65,7 +71,8 @@ class Test_NDItk_multigroup_Metadata( unittest.TestCase ) :
         chunk = Metadata( zaid = '92235.711nm', libname = 'mendf71x', source = '12/22/2011',
                           process = '08/07/2013', awr = 233.0248, weight = 235.043937521619,
                           temperature = 2.53e-8, dilution = 1e+10, groups = 618,
-                          outgoing = { 0 : 30, 1001 : 250 }, reactions = 7, legendre = 5 )
+                          reactions = 7, legendre = 5, outgoing_groups = { 0 : 30, 1001 : 250 },
+                          outgoing_legendre = { 0 : 2, 1001 : 2 } )
 
         verify_chunk( self, chunk )
 

--- a/src/NDItk/MultigroupTable.hpp
+++ b/src/NDItk/MultigroupTable.hpp
@@ -48,6 +48,7 @@ class MultigroupTable {
   /* auxiliary functions */
 
   #include "NDItk/MultigroupTable/src/generateOutgoingStructureMetadata.hpp"
+  #include "NDItk/MultigroupTable/src/generateOutgoingLegendreOrderMetadata.hpp"
   #include "NDItk/MultigroupTable/src/readRecord.hpp"
   #include "NDItk/MultigroupTable/src/readPrimaryStructure.hpp"
   #include "NDItk/MultigroupTable/src/readOutgoingStructure.hpp"

--- a/src/NDItk/MultigroupTable/src/ctor.hpp
+++ b/src/NDItk/MultigroupTable/src/ctor.hpp
@@ -3,10 +3,11 @@
  */
 MultigroupTable() :
     metadata_(), primary_structure_(),
-    velocities_(), weights_(), total_(), xs_(), release_(),
-    outgoing_particles_(), outgoing_structure_(),
-    primary_heating_(), outgoing_heating_(),
-    primary_kerma_(), outgoing_kerma_() {}
+    velocities_(), weights_(), total_(), xs_(), scattering_(),
+    release_(), primary_heating_(), primary_kerma_(),
+    outgoing_particles_(), outgoing_zaids_(),
+    outgoing_structure_(), outgoing_production_(),
+    outgoing_heating_(), outgoing_kerma_() {}
 
 /**
  *  @brief Constructor
@@ -60,8 +61,9 @@ MultigroupTable( std::string zaid, std::string libname,
                  std::vector< multigroup::Kerma > outgoingKerma = {} ) :
     metadata_( std::move( zaid ), std::move( libname ),
                std::move( process ), awr, temperature, dilution,
-               structure.numberGroups(), generateOutgoingStructureMetadata( outgoing ),
-               reaction_xs.numberReactions(), scattering.numberLegendreMoments(),
+               structure.numberGroups(), reaction_xs.numberReactions(),
+               scattering.numberLegendreMoments(), generateOutgoingStructureMetadata( outgoing ),
+               generateOutgoingLegendreOrderMetadata( production ),
                std::move( information ), std::move( source ), std::move( weight ),
                std::nullopt, std::nullopt ),
     primary_structure_( std::move( structure ) ),

--- a/src/NDItk/MultigroupTable/src/generateOutgoingLegendreOrderMetadata.hpp
+++ b/src/NDItk/MultigroupTable/src/generateOutgoingLegendreOrderMetadata.hpp
@@ -1,0 +1,16 @@
+static std::map< unsigned int, unsigned int >
+generateOutgoingLegendreOrderMetadata( const std::vector< multigroup::ScatteringMatrix >& production ) {
+
+  std::map< unsigned int, unsigned int > metadata;
+  for ( const auto& entry : production ) {
+
+    unsigned int particle = entry.particle().value();
+    if ( metadata.find( particle ) != metadata.end() ) {
+
+      Log::error( "Found duplicate number of Legendre moments for outgoing particle \'{}\'", particle );
+      throw std::exception();
+    }
+    metadata[ particle ] = entry.numberLegendreMoments();
+  }
+  return metadata;
+}

--- a/src/NDItk/MultigroupTable/src/readOutgoingData.hpp
+++ b/src/NDItk/MultigroupTable/src/readOutgoingData.hpp
@@ -4,7 +4,7 @@ void readOutgoingData( const std::string& key, std::vector< Record >& vector,
 
   base::Keyword secondary( key );
   unsigned int particle = secondary.particle().value();
-  if ( this->metadata_.numberOutgoingGroups( particle ).has_value() ) {
+  if ( this->metadata_.numberGroups().has_value() ) {
 
     auto pos = std::lower_bound( vector.begin(),
                                  vector.end(),
@@ -22,12 +22,12 @@ void readOutgoingData( const std::string& key, std::vector< Record >& vector,
       }
     }
     pos = vector.insert( pos, Record( particle ) );
-    readRecord( *pos, iter, end, this->metadata_.numberOutgoingGroups( particle ).value() );
+    readRecord( *pos, iter, end, this->metadata_.numberGroups().value() );
   }
   else {
 
     Log::error( "Metadata required for the \'\' record was not found", secondary.keyword() );
-    Log::info( "Required metadata is missing: number of groups in the outgoing group structure" );
+    Log::info( "Required metadata is missing: number of groups in the primary group structure" );
     throw std::exception();
   }
 }

--- a/src/NDItk/MultigroupTable/src/readOutgoingProductionMatrix.hpp
+++ b/src/NDItk/MultigroupTable/src/readOutgoingProductionMatrix.hpp
@@ -5,7 +5,7 @@ void readOutgoingProductionMatrix( const std::string& key, Iterator& iter, const
   unsigned int particle = secondary.particle().value();
   if ( this->metadata_.numberGroups().has_value() &&
        this->metadata_.numberOutgoingGroups( particle ).has_value() &&
-       this->metadata_.numberLegendreMoments().has_value() ) {
+       this->metadata_.numberOutgoingLegendreMoments( particle ).has_value() ) {
 
     auto pos = std::lower_bound( this->outgoing_production_.begin(),
                                  this->outgoing_production_.end(),
@@ -26,7 +26,7 @@ void readOutgoingProductionMatrix( const std::string& key, Iterator& iter, const
     readRecord( *pos, iter, end,
                 this->metadata_.numberGroups().value(),
                 this->metadata_.numberOutgoingGroups( particle ).value(),
-                this->metadata_.numberLegendreMoments().value() );
+                this->metadata_.numberOutgoingLegendreMoments( particle ).value() );
   }
   else {
 
@@ -39,9 +39,9 @@ void readOutgoingProductionMatrix( const std::string& key, Iterator& iter, const
 
       Log::info( "Required metadata is missing: number of groups in the outgoing group structure" );
     }
-    if ( ! this->metadata_.numberLegendreMoments().has_value() ) {
+    if ( ! this->metadata_.numberOutgoingLegendreMoments( particle ).has_value() ) {
 
-      Log::info( "Required metadata is missing: number of Legendre moments" );
+      Log::info( "Required metadata is missing: number of Legendre moments for the outgoing particle" );
     }
     throw std::exception();
   }

--- a/src/NDItk/multigroup/Metadata/src/ctor.hpp
+++ b/src/NDItk/multigroup/Metadata/src/ctor.hpp
@@ -33,7 +33,7 @@ Metadata() : zaid_( base::Keyword( "zaid" ) ),
  *  @param[in] outgoing_groups      the number of groups in the outgoing group structures
  *  @param[in] reactions            the number of reactions defined in the table
  *  @param[in] legendre             the number of legendre moments in the scattering matrix
- *  @param[in] outgoing_groups      the number of legendre moments in the outgoing
+ *  @param[in] outgoing_legendre    the number of legendre moments in the outgoing
  *                                  production matrices
  *  @param[in] information          the table information line (optional)
  *  @param[in] source               the source date (optional)

--- a/src/NDItk/multigroup/Metadata/src/ctor.hpp
+++ b/src/NDItk/multigroup/Metadata/src/ctor.hpp
@@ -14,6 +14,7 @@ Metadata() : zaid_( base::Keyword( "zaid" ) ),
              outgoing_particles_( base::Keyword( "num_sec_parts" ) ),
              outgoing_groups_(),
              legendre_order_( base::Keyword( "pn_order" ) ),
+             outgoing_legendre_order_(),
              upscatter_groups_( base::Keyword( "up_grps" ) ),
              downscatter_groups_( base::Keyword( "down_grps" ) ),
              number_reactions_( base::Keyword( "num_reac" ) ) {}
@@ -26,21 +27,26 @@ Metadata() : zaid_( base::Keyword( "zaid" ) ),
  *  @param[in] process              the processing date
  *  @param[in] awr                  the atomic weight ratio of the target
  *                                  (with respect to the neutron mass)
- *  @param[in] weight               the atomic weight of the target
  *  @param[in] temperature          the temperature of the target
  *  @param[in] dilution             the dilution (aka sigma0)
  *  @param[in] groups               the number of groups in the primary group structure
- *  @param[in] outgoing             the number of groups in the outgoing group structures
+ *  @param[in] outgoing_groups      the number of groups in the outgoing group structures
  *  @param[in] reactions            the number of reactions defined in the table
+ *  @param[in] legendre             the number of legendre moments in the scattering matrix
+ *  @param[in] outgoing_groups      the number of legendre moments in the outgoing
+ *                                  production matrices
+ *  @param[in] information          the table information line (optional)
  *  @param[in] source               the source date (optional)
+ *  @param[in] weight               the atomic weight of the target (optional)
  *  @param[in] upscatter            the number of upscatter groups (optional)
  *  @param[in] downscatter          the number of downscatter groups (optional)
  */
 Metadata( std::string zaid, std::string libname, std::string process,
           double awr, double temperature, double dilution,
           unsigned int groups,
-          const std::map< unsigned int, unsigned int >& outgoing,
           unsigned int reactions, unsigned int legendre,
+          const std::map< unsigned int, unsigned int >& outgoing_groups,
+          const std::map< unsigned int, unsigned int >& outgoing_legendre,
           std::optional< std::string > information = std::nullopt,
           std::optional< std::string > source = std::nullopt,
           std::optional< double  > weight = std::nullopt,
@@ -62,11 +68,12 @@ Metadata( std::string zaid, std::string libname, std::string process,
     temperature_( base::Keyword( "temp" ), temperature ),
     dilution_( base::Keyword( "sig_0" ), dilution ),
     primary_groups_( base::Keyword( "num_grps" ), groups ),
-    outgoing_particles_( outgoing.size() > 0
-                         ? base::SingleIntegerRecord( base::Keyword( "num_sec_parts" ), outgoing.size() )
+    outgoing_particles_( outgoing_groups.size() > 0
+                         ? base::SingleIntegerRecord( base::Keyword( "num_sec_parts" ), outgoing_groups.size() )
                          : base::SingleIntegerRecord( base::Keyword( "num_sec_parts" ) ) ),
-    outgoing_groups_( generateSecondaryGroups( outgoing ) ),
+    outgoing_groups_( generateSecondaryGroups( outgoing_groups ) ),
     legendre_order_( base::SingleIntegerRecord( base::Keyword( "pn_order" ), legendre ) ),
+    outgoing_legendre_order_( generateSecondaryLegendreOrder( outgoing_legendre ) ),
     upscatter_groups_( upscatter.has_value()
                        ? base::SingleIntegerRecord( base::Keyword( "up_grps" ), upscatter.value() )
                        : base::SingleIntegerRecord( base::Keyword( "up_grps" ) ) ),

--- a/src/NDItk/multigroup/Metadata/src/generateSecondaryLegendreOrder.hpp
+++ b/src/NDItk/multigroup/Metadata/src/generateSecondaryLegendreOrder.hpp
@@ -1,0 +1,14 @@
+/**
+ *  @brief A helper function to generate the secondary group recors
+ */
+static std::vector< base::SingleIntegerRecord >
+generateSecondaryLegendreOrder( const std::map< unsigned int, unsigned int >& outgoing ) {
+
+  std::vector< base::SingleIntegerRecord > data;
+  data.reserve( outgoing.size() );
+  for ( auto&& entry : outgoing ) {
+
+    data.emplace_back( base::Keyword( "pn_order", entry.first ), entry.second );
+  }
+  return data;
+}

--- a/src/NDItk/multigroup/Metadata/test/Metadata.test.cpp
+++ b/src/NDItk/multigroup/Metadata/test/Metadata.test.cpp
@@ -33,7 +33,8 @@ SCENARIO( "Metadata" ) {
       double temperature = 2.53e-8;
       double dilution = 1e+10;
       unsigned int groups = 618;
-      std::map< unsigned int, unsigned int > outgoing = { { 0, 30 }, { 1001, 250 } };
+      std::map< unsigned int, unsigned int > outgoing_groups = { { 0, 30 }, { 1001, 250 } };
+      std::map< unsigned int, unsigned int > outgoing_legendre = { { 0, 2 }, { 1001, 2 } };
       int legendre = 5;
       int upscatter = 3;
       int downscatter = 2;
@@ -42,7 +43,8 @@ SCENARIO( "Metadata" ) {
       Metadata chunk( std::move( zaid ), std::move( name ),
                       std::move( process ),
                       awr, temperature, dilution,
-                      groups, outgoing, reactions, legendre,
+                      groups, reactions, legendre,
+                      outgoing_groups, outgoing_legendre,
                       std::move( information ),
                       std::move( source ),
                       weight,
@@ -75,6 +77,8 @@ SCENARIO( "Metadata" ) {
       };
 
       Metadata chunk;
+      chunk.read( readKey( iter, end ), iter, end );
+      chunk.read( readKey( iter, end ), iter, end );
       chunk.read( readKey( iter, end ), iter, end );
       chunk.read( readKey( iter, end ), iter, end );
       chunk.read( readKey( iter, end ), iter, end );
@@ -146,7 +150,11 @@ std::string chunk() {
          "num_grps_0\n"
          "    30\n"
          "num_grps_1001\n"
-         "    250\n";
+         "    250\n"
+         "pn_order_0\n"
+         "    2\n"
+         "pn_order_1001\n"
+         "    2\n";
 }
 
 void verifyChunk( const Metadata& chunk ) {
@@ -168,6 +176,8 @@ void verifyChunk( const Metadata& chunk ) {
   CHECK(   2 == chunk.numberDownscatterGroups() );
   CHECK(   7 == chunk.numberReactions() );
   CHECK(   5 == chunk.numberLegendreMoments() );
+  CHECK(   2 == chunk.numberOutgoingLegendreMoments( 0 ) );
+  CHECK(   2 == chunk.numberOutgoingLegendreMoments( 1001 ) );
 
   CHECK_THROWS( chunk.numberOutgoingGroups( 1 ) );
 }


### PR DESCRIPTION
This fxes the following:
- Outgoing kerma and heating numbers used the outgoing group structure instead of the primary one. 
- pn_order can be set for outgoing production matrices as well